### PR TITLE
Feat/add dotcom components

### DIFF
--- a/packages/ibmdotcom-web-components/components/BackToTop.js
+++ b/packages/ibmdotcom-web-components/components/BackToTop.js
@@ -6,3 +6,9 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+import DDSBackToTop from "@carbon/ibmdotcom-web-components/es/components-react/back-to-top/back-to-top";
+
+export default function BackToTop() {
+  return <DDSBackToTop></DDSBackToTop>;
+}

--- a/packages/ibmdotcom-web-components/components/ButtonGroup.js
+++ b/packages/ibmdotcom-web-components/components/ButtonGroup.js
@@ -1,0 +1,26 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSButtonGroup from "@carbon/ibmdotcom-web-components/es/components-react/button-group/button-group";
+import DDSButtonGroupItem from "@carbon/ibmdotcom-web-components/es/components-react/button-group/button-group-item";
+import ArrowRight20 from "@carbon/icons-react/es/arrow--right/20.js";
+
+export default function ButtonGroup(content) {
+  const { buttons } = content?.fields || {};
+
+  return (
+    <DDSButtonGroup>
+      {buttons.map((button) => {
+        <DDSButtonGroupItem href={button.fields.href}>
+          <ArrowRight20 /> {button.fields.text}
+        </DDSButtonGroupItem>;
+      })}
+    </DDSButtonGroup>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/CalloutQuote.js
+++ b/packages/ibmdotcom-web-components/components/CalloutQuote.js
@@ -1,0 +1,39 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ArrowRight20 from "@carbon/icons-react/es/arrow--right/20.js";
+import DDSCalloutQuote from "@carbon/ibmdotcom-web-components/es/components-react/callout-quote/callout-quote";
+import DDSCalloutLinkWithIcon from "@carbon/ibmdotcom-web-components/es/components-react/callout-quote/callout-link-with-icon";
+import DDSQuoteSourceHeading from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote-source-heading";
+import DDSQuoteSourceCopy from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote-source-copy";
+import DDSQuoteSourceBottomCopy from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote-source-bottom-copy";
+
+export default function CalloutQuote(content) {
+  const {
+    copy,
+    linkHref,
+    linkText,
+    quoteMark,
+    sourceHeading,
+    sourceCopy,
+    sourceBottomCopy,
+  } = content?.fields || {};
+
+  return (
+    <DDSCalloutQuote mark-type={quoteMark}>
+      {copy}
+      <DDSQuoteSourceHeading>{sourceHeading}</DDSQuoteSourceHeading>
+      <DDSQuoteSourceCopy>{sourceCopy}</DDSQuoteSourceCopy>
+      <DDSQuoteSourceBottomCopy>{sourceBottomCopy}</DDSQuoteSourceBottomCopy>
+      <DDSCalloutLinkWithIcon slot="footer" href={linkHref}>
+        {linkText} <ArrowRight20 slot="icon"></ArrowRight20>
+      </DDSCalloutLinkWithIcon>
+    </DDSCalloutQuote>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/CalloutWithMedia.js
+++ b/packages/ibmdotcom-web-components/components/CalloutWithMedia.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSCalloutWithMedia from "@carbon/ibmdotcom-web-components/es/components-react/callout-with-media/callout-with-media";
+import DDSContentBlockHeading from "@carbon/ibmdotcom-web-components/es/components-react/content-block/content-block-heading";
+import DDSCalloutWithMediaCopy from "@carbon/ibmdotcom-web-components/es/components-react/callout-with-media/callout-with-media-copy";
+import DDSCalloutWithMediaImage from "@carbon/ibmdotcom-web-components/es/components-react/callout-with-media/callout-with-media-image";
+import DDSCalloutWithMediaVideo from "@carbon/ibmdotcom-web-components/es/components-react/callout-with-media/callout-with-media-video";
+
+export default function CalloutWithMedia(content) {
+  const {
+    copy,
+    copySize,
+    heading,
+    mediaType,
+    defaultSrc,
+    imageAlt,
+    imageHeading,
+    videoId,
+  } = content?.fields || {};
+
+  return (
+    <DDSCalloutWithMedia>
+      <DDSContentBlockHeading>{heading}</DDSContentBlockHeading>
+      <DDSCalloutWithMediaCopy size={copySize}>{copy}</DDSCalloutWithMediaCopy>
+      {(mediaType === "image" && (
+        <DDSCalloutWithMediaImage
+          alt={imageAlt}
+          default-src={defaultSrc}
+          heading={imageHeading}
+        ></DDSCalloutWithMediaImage>
+      )) ||
+        (mediaType === "video" && (
+          <DDSCalloutWithMediaVideo
+            video-id={videoId}
+          ></DDSCalloutWithMediaVideo>
+        ))}
+    </DDSCalloutWithMedia>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/CardGroup.js
+++ b/packages/ibmdotcom-web-components/components/CardGroup.js
@@ -16,6 +16,7 @@ import DDSImage from "@carbon/ibmdotcom-web-components/es/components-react/image
 
 export default function CardGroup(content) {
   const { cards } = content?.fields || {};
+
   return (
     <DDSCardGroup>
       {cards.map((card, index) => {

--- a/packages/ibmdotcom-web-components/components/CardInCard.js
+++ b/packages/ibmdotcom-web-components/components/CardInCard.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ArrowRight20 from "@carbon/icons-react/es/arrow--right/20.js";
+import DDSVideoCTAContainer from "@carbon/ibmdotcom-web-components/es/components-react/cta/video-cta-container";
+import DDSCardInCard from "@carbon/ibmdotcom-web-components/es/components-react/card-in-card/card-in-card";
+import DDSCardEyebrow from "@carbon/ibmdotcom-web-components/es/components-react/card/card-eyebrow";
+import DDSCardCTAFooter from "@carbon/ibmdotcom-web-components/es/components-react/cta/card-cta-footer";
+import DDSCardInCardImage from "@carbon/ibmdotcom-web-components/es/components-react/card-in-card/card-in-card-image";
+import DDSImageItem from "@carbon/ibmdotcom-web-components/es/components-react/image/image-item";
+import DDSCardHeading from "@carbon/ibmdotcom-web-components/es/components-react/card/card-heading";
+
+export default function CardInCard(content) {
+  const { defaultSrc, eyebrow, heading, href, altText, video, videoId } =
+    content?.fields;
+
+  if (video) {
+    return (
+      <DDSVideoCTAContainer>
+        <DDSCardInCard href={videoId} cta-type="video">
+          <DDSCardEyebrow>{eyebrow}</DDSCardEyebrow>
+          <DDSCardCTAFooter cta-type="video" href={videoId}></DDSCardCTAFooter>
+        </DDSCardInCard>
+      </DDSVideoCTAContainer>
+    );
+  }
+
+  return (
+    <DDSCardInCard href={href}>
+      <DDSCardInCardImage>
+        <DDSImageItem slot="image" alt={altText} default-src={defaultSrc} />
+      </DDSCardInCardImage>
+      {eyebrow && <DDSCardEyebrow>{eyebrow}</DDSCardEyebrow>}
+      <DDSCardHeading>{heading}</DDSCardHeading>
+      <DDSCardCTAFooter>
+        <ArrowRight20 slot="icon" />
+      </DDSCardCTAFooter>
+    </DDSCardInCard>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/CardSectionOffset.js
+++ b/packages/ibmdotcom-web-components/components/CardSectionOffset.js
@@ -1,0 +1,76 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ArrowRight20 from "@carbon/icons-react/es/arrow--right/20.js";
+import DDSVideoCTAContainer from "@carbon/ibmdotcom-web-components/es/components-react/cta/video-cta-container";
+import DDSBackgroundMedia from "@carbon/ibmdotcom-web-components/es/components-react/background-media/background-media";
+import DDSCardCTAFooter from "@carbon/ibmdotcom-web-components/es/components-react/cta/card-cta-footer";
+import DDSCardEyebrow from "@carbon/ibmdotcom-web-components/es/components-react/card/card-eyebrow";
+import DDSCardGroup from "@carbon/ibmdotcom-web-components/es/components-react/card-group/card-group";
+import DDSCardGroupItem from "@carbon/ibmdotcom-web-components/es/components-react/card-group/card-group-item";
+import DDSCardHeading from "@carbon/ibmdotcom-web-components/es/components-react/card/card-heading";
+import DDSCardSectionOffset from "@carbon/ibmdotcom-web-components/es/components-react/card-section-offset/card-section-offset";
+import DDSContentBlockHeading from "@carbon/ibmdotcom-web-components/es/components-react/content-block/content-block-heading";
+import DDSTextCTA from "@carbon/ibmdotcom-web-components/es/components-react/cta/text-cta";
+
+export default function CardSectionOffset(content) {
+  const {
+    alt,
+    cards,
+    cardsPerRow,
+    ctaCopy,
+    ctaType,
+    defaultSrc,
+    download,
+    gradientDirection,
+    heading,
+    href,
+    mobilePosition,
+  } = content?.fields;
+
+  return (
+    <DDSVideoCTAContainer>
+      <DDSCardSectionOffset>
+        <DDSBackgroundMedia
+          gradient-direction={gradientDirection}
+          mobile-position={mobilePosition}
+          alt={alt}
+          default-src={defaultSrc}
+        ></DDSBackgroundMedia>
+        <DDSContentBlockHeading slot="heading">
+          {heading}
+        </DDSContentBlockHeading>
+        <DDSTextCTA
+          slot="action"
+          icon-placement="right"
+          cta-type={ctaType}
+          href={href}
+          download={download}
+        >
+          {ctaType === "video" ? undefined : { ctaCopy }}
+        </DDSTextCTA>
+        <DDSCardGroup slot="card-group" cards-per-row={cardsPerRow}>
+          {cards.map((card, index) => {
+            const { eyebrow, heading, href, copy } = card?.fields;
+            return (
+              <DDSCardGroupItem href={href} key={index}>
+                <DDSCardEyebrow>{eyebrow}</DDSCardEyebrow>
+                <DDSCardHeading slot="heading">{heading}</DDSCardHeading>
+                <p>{copy}</p>
+                <DDSCardCTAFooter slot="footer">
+                  <ArrowRight20 slot="icon" />
+                </DDSCardCTAFooter>
+              </DDSCardGroupItem>
+            );
+          })}
+        </DDSCardGroup>
+      </DDSCardSectionOffset>
+    </DDSVideoCTAContainer>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/CardSectionSimple.js
+++ b/packages/ibmdotcom-web-components/components/CardSectionSimple.js
@@ -1,0 +1,63 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSCardGroupItem from "@carbon/ibmdotcom-web-components/es/components-react/card-group/card-group-item";
+import DDSImage from "@carbon/ibmdotcom-web-components/es/components-react/image/image";
+import DDSCardEyebrow from "@carbon/ibmdotcom-web-components/es/components-react/card/card-eyebrow";
+import DDSCardHeading from "@carbon/ibmdotcom-web-components/es/components-react/card/card-heading";
+import DDSCardCTAFooter from "@carbon/ibmdotcom-web-components/es/components-react/cta/card-cta-footer";
+import DDSCardSectionSimple from "@carbon/ibmdotcom-web-components/es/components-react/card-section-simple/card-section-simple";
+import DDSContentSectionHeading from "@carbon/ibmdotcom-web-components/es/components-react/content-section/content-section-heading";
+import DDSCardGroup from "@carbon/ibmdotcom-web-components/es/components-react/card-group/card-group";
+
+export default function CardSectionSimple(content) {
+  const { cards, heading, cta } = content?.fields || {};
+
+  return (
+    <DDSCardSectionSimple>
+      <DDSContentSectionHeading>{heading}</DDSContentSectionHeading>
+      <DDSCardGroup>
+        {cards.map((card, index) => {
+          const { eyebrow, heading, href, copy, altText, image } = card?.fields;
+          <DDSCardGroupItem href={href} cta-type="local">
+            {image ? (
+              <DDSImage
+                slot="image"
+                alt={altText}
+                default-src={card.defaultSrc}
+                key={index}
+              />
+            ) : (
+              ""
+            )}
+            <DDSCardEyebrow>{eyebrow}</DDSCardEyebrow>
+            <DDSCardHeading>{heading}</DDSCardHeading>
+            <p>{copy}</p>
+            <DDSCardCTAFooter slot="footer"></DDSCardCTAFooter>
+          </DDSCardGroupItem>;
+        })}
+        {cta ? (
+          <DDSCardGroupItem
+            href={cta.href}
+            color-scheme="inverse"
+            cta-type="local"
+          >
+            <DDSCardHeading>{cta.heading}</DDSCardHeading>
+            <DDSCardCTAFooter
+              slot="footer"
+              color-scheme="inverse"
+            ></DDSCardCTAFooter>
+          </DDSCardGroupItem>
+        ) : (
+          ""
+        )}
+      </DDSCardGroup>
+    </DDSCardSectionSimple>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/Carousel.js
+++ b/packages/ibmdotcom-web-components/components/Carousel.js
@@ -1,0 +1,25 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import dynamic from "next/dynamic";
+import DDSCarousel from "@carbon/ibmdotcom-web-components/es/components-react/carousel/carousel";
+
+const Card = dynamic(import("./Card"), { ssr: false });
+
+export default function Carousel(content) {
+  const { cards } = content?.fields || {};
+
+  return (
+    <DDSCarousel>
+      {cards.map((card, index) => {
+        return <Card {...card} key={index} />;
+      })}
+    </DDSCarousel>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/ComponentRenderer.js
+++ b/packages/ibmdotcom-web-components/components/ComponentRenderer.js
@@ -30,9 +30,6 @@ const CardSectionCarousel = dynamic(import("./CardSectionCarousel"), {
   ssr: false,
 });
 const CardSection = dynamic(import("./CardSection"), { ssr: false });
-const PieChart = dynamic(import("./PieChart"), {
-  ssr: false,
-});
 const ThemeZone = dynamic(import("./ThemeZone"), { ssr: false });
 
 // import exploreMore from "../data/exploreMore.json";
@@ -51,7 +48,6 @@ const map = {
   "dds-background-media": BackgroundMedia,
   "dds-leadspace": Leadspace,
   "dds-table-of-contents": TableOfContents,
-  pieChart: PieChart,
   themeZone: ThemeZone,
 };
 

--- a/packages/ibmdotcom-web-components/pages/examples/[slug].js
+++ b/packages/ibmdotcom-web-components/pages/examples/[slug].js
@@ -10,8 +10,6 @@
 import dynamic from "next/dynamic";
 import * as contentful from "../../utils/contentful";
 
-// const ContentBlock = dynamic(import('../../components/ContentBlock'), { ssr: false })
-// const Card = dynamic(import('../../components/Card'), { ssr: false })
 const ComponentRenderer = dynamic(
   import("../../components/ComponentRenderer"),
   { ssr: false }


### PR DESCRIPTION
### Related Ticket(s)

#27 
#28
#29
#30 
#32 
#33 
#34 
#35 

### Description

Adds the following components:
- `BackToTop`
- `ButtonGroup`
- `CalloutQuote`
- `CalloutWithMedia`
- `CardInCard`
- `CardSectionOffset`
- `CardSectionSimple`
- `Carousel`

### Changelog

**New**

- adds various new component wrappers

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}
