### PR TITLE
chore(wrappers): add wrappers for various components

### DIFF
--- a/packages/ibmdotcom-web-components/components/ComponentRenderer.js
+++ b/packages/ibmdotcom-web-components/components/ComponentRenderer.js
@@ -37,6 +37,9 @@ const CardSection = dynamic(import("./CardSection"), { ssr: false });
 const Quote = dynamic(import("./Quote"), {
   ssr: false,
 });
+const SearchWithTypeahead = dynamic(import("./SearchWithTypeahead"), {
+  ssr: false,
+});
 const ThemeZone = dynamic(import("./ThemeZone"), { ssr: false });
 
 // import exploreMore from "../data/exploreMore.json";
@@ -57,6 +60,7 @@ const map = {
   "dds-image": Image,
   "dds-leadspace": Leadspace,
   "dds-quote": Quote,
+  "dds-search-with-typeahead": SearchWithTypeahead,
   "dds-table-of-contents": TableOfContents,
   themeZone: ThemeZone,
 };

--- a/packages/ibmdotcom-web-components/components/ComponentRenderer.js
+++ b/packages/ibmdotcom-web-components/components/ComponentRenderer.js
@@ -43,6 +43,9 @@ const Quote = dynamic(import("./Quote"), {
 const SearchWithTypeahead = dynamic(import("./SearchWithTypeahead"), {
   ssr: false,
 });
+const TabsExtended = dynamic(import("./TabsExtended"), {
+  ssr: false,
+});
 const VideoPlayer = dynamic(import("./VideoPlayer"), {
   ssr: false,
 });
@@ -71,6 +74,7 @@ const map = {
   "dds-quote": Quote,
   "dds-search-with-typeahead": SearchWithTypeahead,
   "dds-table-of-contents": TableOfContents,
+  "dds-tabs-extended": TabsExtended,
   "dds-video-player-container": VideoPlayer,
   themeZone: ThemeZone,
 };

--- a/packages/ibmdotcom-web-components/components/ComponentRenderer.js
+++ b/packages/ibmdotcom-web-components/components/ComponentRenderer.js
@@ -34,6 +34,9 @@ const Image = dynamic(import("./Image"), {
   ssr: false,
 });
 const CardSection = dynamic(import("./CardSection"), { ssr: false });
+const Quote = dynamic(import("./Quote"), {
+  ssr: false,
+});
 const ThemeZone = dynamic(import("./ThemeZone"), { ssr: false });
 
 // import exploreMore from "../data/exploreMore.json";
@@ -53,6 +56,7 @@ const map = {
   "dds-horizontal-rule": HorizontalRule,
   "dds-image": Image,
   "dds-leadspace": Leadspace,
+  "dds-quote": Quote,
   "dds-table-of-contents": TableOfContents,
   themeZone: ThemeZone,
 };

--- a/packages/ibmdotcom-web-components/components/ComponentRenderer.js
+++ b/packages/ibmdotcom-web-components/components/ComponentRenderer.js
@@ -29,10 +29,11 @@ const TableOfContents = dynamic(import("./TableOfContents"), { ssr: false });
 const CardSectionCarousel = dynamic(import("./CardSectionCarousel"), {
   ssr: false,
 });
-const CardSection = dynamic(import("./CardSection"), { ssr: false });
-const PieChart = dynamic(import("./PieChart"), {
+const HorizontalRule = dynamic(import("./HorizontalRule"), { ssr: false });
+const Image = dynamic(import("./Image"), {
   ssr: false,
 });
+const CardSection = dynamic(import("./CardSection"), { ssr: false });
 const ThemeZone = dynamic(import("./ThemeZone"), { ssr: false });
 
 // import exploreMore from "../data/exploreMore.json";
@@ -49,9 +50,10 @@ const map = {
   "dds-card-section-with-images": CardSection,
   "dds-card-section-carousel": CardSectionCarousel,
   "dds-background-media": BackgroundMedia,
+  "dds-horizontal-rule": HorizontalRule,
+  "dds-image": Image,
   "dds-leadspace": Leadspace,
   "dds-table-of-contents": TableOfContents,
-  pieChart: PieChart,
   themeZone: ThemeZone,
 };
 

--- a/packages/ibmdotcom-web-components/components/HorizontalRule.js
+++ b/packages/ibmdotcom-web-components/components/HorizontalRule.js
@@ -1,0 +1,22 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSHorizontalRule from "@carbon/ibmdotcom-web-components/es/components-react/horizontal-rule/horizontal-rule";
+
+export default function HorizontalRule(content) {
+  const { type, size, contrast, weight } = content?.fields || {};
+  return (
+    <DDSHorizontalRule
+      type={type}
+      size={size}
+      contrast={contrast}
+      weight={weight}
+    ></DDSHorizontalRule>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/HorizontalRule.js
+++ b/packages/ibmdotcom-web-components/components/HorizontalRule.js
@@ -10,13 +10,14 @@
 import DDSHorizontalRule from "@carbon/ibmdotcom-web-components/es/components-react/horizontal-rule/horizontal-rule";
 
 export default function HorizontalRule(content) {
-  const { type, size, contrast, weight } = content?.fields || {};
+  const { type, size, contrast, weight, slot } = content?.fields || {};
   return (
     <DDSHorizontalRule
       type={type}
       size={size}
       contrast={contrast}
       weight={weight}
+      slot={slot}
     ></DDSHorizontalRule>
   );
 }

--- a/packages/ibmdotcom-web-components/components/Image.js
+++ b/packages/ibmdotcom-web-components/components/Image.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSImage from "@carbon/ibmdotcom-web-components/es/components-react/image/image";
+import DDSImageItem from "@carbon/ibmdotcom-web-components/es/components-react/image/image-item";
+
+export default function HorizontalRule(content) {
+  const { alt, defaultSrc, border, heading, copy, lightbox, imageItems } =
+    content?.fields || {};
+
+  const { url } = defaultSrc?.fields?.file || {};
+  return (
+    <DDSImage
+      alt={alt}
+      defaultSrc={"https:" + url}
+      border={border}
+      heading={heading}
+      copy={copy}
+      lightbox={lightbox}
+    >
+      {!imageItems
+        ? undefined
+        : imageItems.map((image, index) => {
+            const { minWidth } = image.fields;
+            const { url } = image.fields.image.fields.file;
+
+            return (
+              <DDSImageItem
+                media={`(min-width: ${minWidth})`}
+                srcset={"https:" + url}
+                key={index}
+              ></DDSImageItem>
+            );
+          })}
+    </DDSImage>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/LeadspaceWithSearch.js
+++ b/packages/ibmdotcom-web-components/components/LeadspaceWithSearch.js
@@ -29,10 +29,25 @@ export default function LeadspaceWithSearch(content) {
     contentCopy,
   } = content?.fields || {};
 
+  const backgroundMediaFields = {
+    fields: { ...backgroundMedia?.fields, slot: "image" },
+  };
+
+  const searchWithTypeaheadFields = {
+    fields: { slot: "search", alternate: true },
+  };
+
+  const horizontalRuleFields = {
+    fields: { slot: "hr" },
+  };
+
   return (
-    <DDSLeadspaceWithSearch adjacent-theme={adjacentTheme}>
+    <DDSLeadspaceWithSearch
+      adjacent-theme={adjacentTheme}
+      has-image={backgroundMedia || undefined}
+    >
       {!backgroundMedia ? undefined : (
-        <BackgroundMedia slot="image" {...backgroundMedia} />
+        <BackgroundMedia {...backgroundMediaFields} />
       )}
       <DDSLeadspaceWithSearchHeading>{heading}</DDSLeadspaceWithSearchHeading>
       <DDSLeadspaceWithSearchContent>
@@ -43,8 +58,8 @@ export default function LeadspaceWithSearch(content) {
           {contentCopy}
         </DDSLeadspaceWithSearchContentCopy>
       </DDSLeadspaceWithSearchContent>
-      <SearchWithTypeahead slot="search" leadspace-search></SearchWithTypeahead>
-      <HorizontalRule slot="hr"></HorizontalRule>
+      <SearchWithTypeahead {...searchWithTypeaheadFields}></SearchWithTypeahead>
+      <HorizontalRule {...horizontalRuleFields} />
     </DDSLeadspaceWithSearch>
   );
 }

--- a/packages/ibmdotcom-web-components/components/LinkWithIcon.js
+++ b/packages/ibmdotcom-web-components/components/LinkWithIcon.js
@@ -34,22 +34,18 @@ const iconMap = {
   Calendar20: <Calendar20 slot="icon" />,
   Email20: <Email20 slot="icon" />,
   Chat20: <Chat20 slot="icon" />,
-}
+};
 
 export default function LinkWithIcon(content) {
-  const {
-    iconPlacement,
-    disabled,
-    href,
-    text,
-    icon,
-  } = content?.fields || {};
+  const { iconPlacement, disabled, href, text, icon, slot } =
+    content?.fields || {};
   return (
     <DDSLinkWithIcon
       iconPlacement={iconPlacement}
       disabled={disabled}
       href={href}
-      >
+      slot={slot}
+    >
       {text} {iconMap[icon]}
     </DDSLinkWithIcon>
   );

--- a/packages/ibmdotcom-web-components/components/Quote.js
+++ b/packages/ibmdotcom-web-components/components/Quote.js
@@ -1,0 +1,36 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSQuote from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote";
+import DDSLinkWithIcon from "@carbon/ibmdotcom-web-components/es/components-react/link-with-icon/link-with-icon";
+import DDSQuoteSourceHeading from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote-source-heading";
+import DDSQuoteSourceCopy from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote-source-copy";
+import DDSQuoteSourceBottomCopy from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote-source-bottom-copy";
+
+export default function BackgroundMedia(content) {
+  const {
+    copy,
+    quoteMark,
+    sourceHeading,
+    sourceCopy,
+    sourceBottomCopy,
+    colorScheme,
+  } = content?.fields || {};
+  return (
+    <DDSQuote color-scheme={colorScheme} mark-type={quoteMark}>
+      {copy}
+      <DDSQuoteSourceHeading>{sourceHeading}</DDSQuoteSourceHeading>
+      <DDSQuoteSourceCopy>{sourceCopy}</DDSQuoteSourceCopy>
+      <DDSQuoteSourceBottomCopy>{sourceBottomCopy}</DDSQuoteSourceBottomCopy>
+      <DDSLinkWithIcon slot="footer" href="https://example.com">
+        Link with icon
+      </DDSLinkWithIcon>
+    </DDSQuote>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/Quote.js
+++ b/packages/ibmdotcom-web-components/components/Quote.js
@@ -7,11 +7,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import dynamic from "next/dynamic";
 import DDSQuote from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote";
-import DDSLinkWithIcon from "@carbon/ibmdotcom-web-components/es/components-react/link-with-icon/link-with-icon";
 import DDSQuoteSourceHeading from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote-source-heading";
 import DDSQuoteSourceCopy from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote-source-copy";
 import DDSQuoteSourceBottomCopy from "@carbon/ibmdotcom-web-components/es/components-react/quote/quote-source-bottom-copy";
+
+const LinkWithIcon = dynamic(import("./LinkWithIcon"), {
+  ssr: false,
+});
 
 export default function Quote(content) {
   const {
@@ -21,16 +25,22 @@ export default function Quote(content) {
     sourceCopy,
     sourceBottomCopy,
     colorScheme,
+    linkWithIcon,
   } = content?.fields || {};
+
+  const linkWithIconFields = {
+    fields: { ...linkWithIcon?.fields, slot: "footer" },
+  };
+
+  console.log("linkWithIcon", linkWithIcon);
+
   return (
     <DDSQuote color-scheme={colorScheme} mark-type={quoteMark}>
       {copy}
       <DDSQuoteSourceHeading>{sourceHeading}</DDSQuoteSourceHeading>
       <DDSQuoteSourceCopy>{sourceCopy}</DDSQuoteSourceCopy>
       <DDSQuoteSourceBottomCopy>{sourceBottomCopy}</DDSQuoteSourceBottomCopy>
-      <DDSLinkWithIcon slot="footer" href="https://example.com">
-        Link with icon
-      </DDSLinkWithIcon>
+      <LinkWithIcon {...linkWithIconFields} />
     </DDSQuote>
   );
 }

--- a/packages/ibmdotcom-web-components/components/SearchWithTypeahead.js
+++ b/packages/ibmdotcom-web-components/components/SearchWithTypeahead.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSSearchWithTypeahead from "@carbon/ibmdotcom-web-components/es/components-react/search-with-typeahead/search-with-typeahead";
+
+export default function SearchWithTypeahead(content) {
+  const { alternate } = content?.fields || {};
+  return (
+    <DDSSearchWithTypeahead
+      leadspace-search={alternate || undefined}
+    ></DDSSearchWithTypeahead>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/TabsExtended.js
+++ b/packages/ibmdotcom-web-components/components/TabsExtended.js
@@ -1,0 +1,40 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import dynamic from "next/dynamic";
+import DDSTabsExtended from "@carbon/ibmdotcom-web-components/es/components-react/tabs-extended/tabs-extended";
+import DDSTab from "@carbon/ibmdotcom-web-components/es/components-react/tabs-extended/tab";
+
+const ComponentRenderer = dynamic(import("./ComponentRenderer"), {
+  ssr: false,
+});
+
+export default function TabsExtended(content) {
+  const { orientation, tabs } = content?.fields || {};
+
+  return (
+    <DDSTabsExtended orientation={orientation || undefined}>
+      {tabs.map((tab, index) => {
+        const { label, disabled, children, selected } = tab.fields;
+        return (
+          <DDSTab
+            label={label}
+            disabled={disabled || undefined}
+            selected={selected || undefined}
+            key={index}
+          >
+            {children?.map((child, index) => {
+              return <ComponentRenderer content={child} key={index} />;
+            })}
+          </DDSTab>
+        );
+      })}
+    </DDSTabsExtended>
+  );
+}


### PR DESCRIPTION
### Related Ticket(s)

Image #44
Horizontal rule #43
Quote #51
Search with typeahead #59
Leadspace search #58
Tabs extended #61

### Description

Adds the following components:

- `image`
- `horizontal rule`
- `quote`
- `search-with-typeahead`
- `leadspace-with-search`
- `tabs-extended`

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}
