### PR TITLE
feat(components): logo grif and tag components

### DIFF
--- a/packages/ibmdotcom-web-components/components/ComponentRenderer.js
+++ b/packages/ibmdotcom-web-components/components/ComponentRenderer.js
@@ -37,6 +37,9 @@ const Image = dynamic(import("./Image"), {
 const LeadspaceWithSearch = dynamic(import("./LeadspaceWithSearch"), {
   ssr: false,
 });
+const LogoGrid = dynamic(import("./LogoGrid"), {
+  ssr: false,
+});
 const Quote = dynamic(import("./Quote"), {
   ssr: false,
 });
@@ -44,6 +47,12 @@ const SearchWithTypeahead = dynamic(import("./SearchWithTypeahead"), {
   ssr: false,
 });
 const TabsExtended = dynamic(import("./TabsExtended"), {
+  ssr: false,
+});
+const TagLink = dynamic(import("./TagLink"), {
+  ssr: false,
+});
+const TagGroup = dynamic(import("./TagGroup"), {
   ssr: false,
 });
 const VideoPlayer = dynamic(import("./VideoPlayer"), {
@@ -69,12 +78,15 @@ const map = {
   "dds-horizontal-rule": HorizontalRule,
   "dds-image": Image,
   "dds-leadspace": Leadspace,
+  "dds-logo-grid": LogoGrid,
   "dds-link-with-icon": LinkWithIcon,
   "dds-leadspace-with-search": LeadspaceWithSearch,
   "dds-quote": Quote,
   "dds-search-with-typeahead": SearchWithTypeahead,
   "dds-table-of-contents": TableOfContents,
   "dds-tabs-extended": TabsExtended,
+  "dds-tag-link": TagLink,
+  "dds-tag-group": TagGroup,
   "dds-video-player-container": VideoPlayer,
   themeZone: ThemeZone,
 };

--- a/packages/ibmdotcom-web-components/components/LogoGrid.js
+++ b/packages/ibmdotcom-web-components/components/LogoGrid.js
@@ -1,0 +1,51 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSCardLinkHeading from "@carbon/ibmdotcom-web-components/es/components-react/card-link/card-link-heading";
+import DDSContentBlockHeading from "@carbon/ibmdotcom-web-components/es/components-react/content-block/content-block-heading";
+import DDSLogoGrid from "@carbon/ibmdotcom-web-components/es/components-react/logo-grid/logo-grid";
+import DDSLogoGridItem from "@carbon/ibmdotcom-web-components/es/components-react/logo-grid/logo-grid-item";
+import DDSLogoGridLink from "@carbon/ibmdotcom-web-components/es/components-react/logo-grid/logo-grid-link";
+
+export default function LogoGrid(content) {
+  const { heading, logoImages, columnCount, logoAspectRatio, cta, hideBorder } = content?.fields || {};
+
+	console.log(cta)
+	const { href } = cta?.fields || {};
+
+  return (
+		<DDSLogoGrid logoCount={columnCount} logoRatio={logoAspectRatio} hideBorder={hideBorder}>
+			<DDSContentBlockHeading>{heading}</DDSContentBlockHeading>
+      {logoImages.map((card) => {
+        const { image, alt } = card?.fields;
+				const { url } = image?.fields?.file || {};
+        return (
+					<DDSLogoGridItem defaultSrc={"https://" + url} alt={alt}></DDSLogoGridItem>
+        );
+      })}
+			{cta && 
+				<DDSLogoGridLink href={href}>
+					<DDSCardLinkHeading>{cta?.fields.heading}</DDSCardLinkHeading>
+					<svg
+						slot="footer"
+						focusable="false"
+						preserveAspectRatio="xMidYMid meet"
+						xmlns="http://www.w3.org/2000/svg"
+						fill="currentColor"
+						aria-hidden="true"
+						width="20"
+						height="20"
+						viewBox="0 0 20 20"
+					>
+						<path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+					</svg>
+				</DDSLogoGridLink>}
+		</DDSLogoGrid>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/TagGroup.js
+++ b/packages/ibmdotcom-web-components/components/TagGroup.js
@@ -1,0 +1,26 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSTagGroup from "@carbon/ibmdotcom-web-components/es/components-react/tag-group/tag-group";
+import DDSTagLink from "@carbon/ibmdotcom-web-components/es/components-react/tag-link/tag-link";
+
+export default function TagGroup(content) {
+  const { tags } = content?.fields || {};
+
+  return (
+		<DDSTagGroup>
+      {tags.map((card) => {
+        const { href, copy } = card?.fields;
+        return (
+					<DDSTagLink href={href}>{copy}</DDSTagLink>
+        );
+      })}
+		</DDSTagGroup>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/TagLink.js
+++ b/packages/ibmdotcom-web-components/components/TagLink.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSTagLink from "@carbon/ibmdotcom-web-components/es/components-react/tag-link/tag-link";
+
+export default function TagLink(content) {
+  const { href, copy } = content?.fields || {};
+
+  return (
+		<DDSTagLink href={href}>
+			{copy}
+		</DDSTagLink>
+  );
+}


### PR DESCRIPTION
### Related Ticket(s)
#45 
#46 
#47 

### Description
Added LogoGrid, TagGroup, and TagLink to Contentful and its respective wrappers.

### Changelog

**New**

- LogoGrid wrapper
- TagGroup wrapper
- TagLink wrapper
