### PR TITLE
feat(components): add cta, feature card, section, locale modal, universal banner

### DIFF
--- a/packages/ibmdotcom-web-components/components/CTA.js
+++ b/packages/ibmdotcom-web-components/components/CTA.js
@@ -1,0 +1,34 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSCTAHead from "@carbon/ibmdotcom-web-components/es/components-react/cta/cta";
+import DDSCardHeading from "@carbon/ibmdotcom-web-components/es/components-react/card/card-heading";
+
+/* eslint-disable no-unused-vars */
+import DDSCTAButton from "@carbon/ibmdotcom-web-components/es/components-react/cta/button-cta";
+import DDSCTACardLink from "@carbon/ibmdotcom-web-components/es/components-react/cta/card-link-cta";
+import DDSCTAFeature from "@carbon/ibmdotcom-web-components/es/components-react/cta/feature-cta";
+/* eslint-enable no-unused-vars */
+
+import DDSCardLinkHeading from "@carbon/ibmdotcom-web-components/es/components-react/card-link/card-link-heading";
+import DDSCardCTAFooter from "@carbon/ibmdotcom-web-components/es/components-react/cta/card-cta-footer";
+import DDSFeatureCTAFooter from "@carbon/ibmdotcom-web-components/es/components-react/cta/feature-cta-footer";
+
+export default function CTA(content) {
+  const { ctaStyle, heading, copy, href, ctaType, iconPlacement } = content?.fields || {};
+  return (
+			<DDSCTAHead ctaStyle={ctaStyle} href={href} ctaType={ctaType} iconPlacement={iconPlacement}>
+				{ctaStyle === 'feature' && heading && <DDSCardHeading>{heading}</DDSCardHeading>}
+				{ctaStyle === 'card-link' && heading && <DDSCardLinkHeading>{heading}</DDSCardLinkHeading>}
+				{copy}
+				{ctaStyle === 'feature' && <DDSFeatureCTAFooter></DDSFeatureCTAFooter>}
+				{(ctaStyle === 'card' || ctaStyle === 'card-link') && <DDSCardCTAFooter></DDSCardCTAFooter>}
+			</DDSCTAHead>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/ComponentRenderer.js
+++ b/packages/ibmdotcom-web-components/components/ComponentRenderer.js
@@ -40,14 +40,11 @@ const Image = dynamic(import("./Image"), {
 const LeadspaceWithSearch = dynamic(import("./LeadspaceWithSearch"), {
   ssr: false,
 });
-<<<<<<< Updated upstream
-=======
 const LeavingIBM = dynamic(import("./LeavingIBM"), { ssr: false });
 const LocaleModal = dynamic(import("./LocaleModal"), { ssr: false });
 const LogoGrid = dynamic(import("./LogoGrid"), {
   ssr: false,
 });
->>>>>>> Stashed changes
 const Quote = dynamic(import("./Quote"), {
   ssr: false,
 });
@@ -85,23 +82,15 @@ const map = {
   "dds-image": Image,
   "dds-leaving-ibm-container": LeavingIBM,
   "dds-leadspace": Leadspace,
-<<<<<<< Updated upstream
-=======
   "dds-locale-modal": LocaleModal,
   "dds-logo-grid": LogoGrid,
->>>>>>> Stashed changes
   "dds-link-with-icon": LinkWithIcon,
   "dds-leadspace-with-search": LeadspaceWithSearch,
   "dds-quote": Quote,
   "dds-search-with-typeahead": SearchWithTypeahead,
   "dds-table-of-contents": TableOfContents,
   "dds-tabs-extended": TabsExtended,
-<<<<<<< Updated upstream
-=======
-  "dds-tag-link": TagLink,
-  "dds-tag-group": TagGroup,
   "dds-universal-banner": UniversalBanner,
->>>>>>> Stashed changes
   "dds-video-player-container": VideoPlayer,
   themeZone: ThemeZone,
 };

--- a/packages/ibmdotcom-web-components/components/ComponentRenderer.js
+++ b/packages/ibmdotcom-web-components/components/ComponentRenderer.js
@@ -24,6 +24,9 @@ const ContentGroupPictograms = dynamic(import("./ContentGroupPictograms"), {
 });
 const ContentItem = dynamic(import("./ContentItem"), { ssr: false });
 const Card = dynamic(import("./Card"), { ssr: false });
+const CTA = dynamic(import("./CTA"), { ssr: false });
+const FeatureCard = dynamic(import("./FeatureCard"), { ssr: false });
+const FeatureSection = dynamic(import("./FeatureSection"), { ssr: false });
 const Leadspace = dynamic(import("./Leadspace"), { ssr: false });
 const LinkWithIcon = dynamic(import("./LinkWithIcon"), { ssr: false });
 const TableOfContents = dynamic(import("./TableOfContents"), { ssr: false });
@@ -37,6 +40,14 @@ const Image = dynamic(import("./Image"), {
 const LeadspaceWithSearch = dynamic(import("./LeadspaceWithSearch"), {
   ssr: false,
 });
+<<<<<<< Updated upstream
+=======
+const LeavingIBM = dynamic(import("./LeavingIBM"), { ssr: false });
+const LocaleModal = dynamic(import("./LocaleModal"), { ssr: false });
+const LogoGrid = dynamic(import("./LogoGrid"), {
+  ssr: false,
+});
+>>>>>>> Stashed changes
 const Quote = dynamic(import("./Quote"), {
   ssr: false,
 });
@@ -51,6 +62,7 @@ const VideoPlayer = dynamic(import("./VideoPlayer"), {
 });
 const CardSection = dynamic(import("./CardSection"), { ssr: false });
 const ThemeZone = dynamic(import("./ThemeZone"), { ssr: false });
+const UniversalBanner = dynamic(import("./UniversalBanner"), { ssr: false });
 
 // import exploreMore from "../data/exploreMore.json";
 
@@ -65,16 +77,31 @@ const map = {
   "dds-card-group": CardGroup,
   "dds-card-section-with-images": CardSection,
   "dds-card-section-carousel": CardSectionCarousel,
+  "dds-cta": CTA,
+  "dds-feature-card": FeatureCard,
+  "dds-feature-section": FeatureSection,
   "dds-background-media": BackgroundMedia,
   "dds-horizontal-rule": HorizontalRule,
   "dds-image": Image,
+  "dds-leaving-ibm-container": LeavingIBM,
   "dds-leadspace": Leadspace,
+<<<<<<< Updated upstream
+=======
+  "dds-locale-modal": LocaleModal,
+  "dds-logo-grid": LogoGrid,
+>>>>>>> Stashed changes
   "dds-link-with-icon": LinkWithIcon,
   "dds-leadspace-with-search": LeadspaceWithSearch,
   "dds-quote": Quote,
   "dds-search-with-typeahead": SearchWithTypeahead,
   "dds-table-of-contents": TableOfContents,
   "dds-tabs-extended": TabsExtended,
+<<<<<<< Updated upstream
+=======
+  "dds-tag-link": TagLink,
+  "dds-tag-group": TagGroup,
+  "dds-universal-banner": UniversalBanner,
+>>>>>>> Stashed changes
   "dds-video-player-container": VideoPlayer,
   themeZone: ThemeZone,
 };

--- a/packages/ibmdotcom-web-components/components/FeatureCard.js
+++ b/packages/ibmdotcom-web-components/components/FeatureCard.js
@@ -1,0 +1,49 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import dynamic from "next/dynamic";
+import DDSFeatureCard from "@carbon/ibmdotcom-web-components/es/components-react/feature-card/feature-card";
+import DDSCardHeading from "@carbon/ibmdotcom-web-components/es/components-react/card/card-heading";
+import DDSFeatureCardFooter from "@carbon/ibmdotcom-web-components/es/components-react/feature-card/feature-card-footer";
+import DDSCardEyebrow from "@carbon/ibmdotcom-web-components/es/components-react/card/card-eyebrow";
+
+const Image = dynamic(import("./Image"), { ssr: false });
+
+export default function FeatureCard(content) {
+  const { eyebrow, heading, copy, href, image, size } = content?.fields || {};
+	let properSize = size !== 'large' ? null : size;
+
+  const imageFields = {
+    fields: { ...image?.fields },
+  };
+
+  return (
+		<DDSFeatureCard size={properSize} href={href}>
+      {image && <Image slot='image' {...imageFields} />}
+			{eyebrow && size === 'large' && <DDSCardEyebrow slot='eyebrow'>{eyebrow}</DDSCardEyebrow>}
+			<DDSCardHeading slot='heading'>{heading}</DDSCardHeading>
+			{copy && size === 'large' && <p>{copy}</p>}
+			<DDSFeatureCardFooter>
+				<svg
+					slot="icon"
+					focusable="false"
+					preserveAspectRatio="xMidYMid meet"
+					xmlns="http://www.w3.org/2000/svg"
+					fill="currentColor"
+					aria-hidden="true"
+					width="20"
+					height="20"
+					viewBox="0 0 20 20"
+				>
+					<path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path>
+				</svg>
+			</DDSFeatureCardFooter>
+		</DDSFeatureCard>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/FeatureSection.js
+++ b/packages/ibmdotcom-web-components/components/FeatureSection.js
@@ -1,0 +1,44 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import dynamic from "next/dynamic";
+import DDSCardEyebrow from "@carbon/ibmdotcom-web-components/es/components-react/card/card-eyebrow";
+import DDSContentBlockHeading from "@carbon/ibmdotcom-web-components/es/components-react/content-block/content-block-heading";
+import DDSContentItemParagraph from "@carbon/ibmdotcom-web-components/es/components-react/content-item/content-item-paragraph";
+import DDSFeatureSection from "@carbon/ibmdotcom-web-components/es/components-react/feature-section/feature-section"
+import DDSFeatureSectionCardLink from "@carbon/ibmdotcom-web-components/es/components-react/feature-section/feature-section-card-link"
+
+import DDSCardLinkHeading from "@carbon/ibmdotcom-web-components/es/components-react/card-link/card-link-heading";
+import DDSCardCTAFooter from "@carbon/ibmdotcom-web-components/es/components-react/cta/card-cta-footer";
+
+const Image = dynamic(import("./Image"), { ssr: false });
+
+export default function FeatureCard(content) {
+  const { eyebrow, heading, copy, mediaAlignment, image, href, cta} = content?.fields || {};
+
+	const cardHeading = cta?.fields.heading || {};
+	const cardType = cta?.fields.ctaType || {};
+  const imageFields = {
+    fields: { ...image?.fields },
+  };
+
+  return (
+		<DDSFeatureSection mediaAlignment={mediaAlignment}>
+      {image && <Image slot='image' {...imageFields} />}
+			{eyebrow && <DDSCardEyebrow slot='eyebrow'>{eyebrow}</DDSCardEyebrow>}
+			<DDSContentBlockHeading slot='heading'>{heading}</DDSContentBlockHeading>
+			{copy && <DDSContentItemParagraph slot="copy">{copy}</DDSContentItemParagraph>}
+
+			<DDSFeatureSectionCardLink slot="footer" color-scheme="inverse" href={href} ctaType={cardType}>
+				<DDSCardLinkHeading>{cardHeading}</DDSCardLinkHeading>
+				<DDSCardCTAFooter color-scheme="inverse"></DDSCardCTAFooter>
+			</DDSFeatureSectionCardLink>
+		</DDSFeatureSection>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/Image.js
+++ b/packages/ibmdotcom-web-components/components/Image.js
@@ -13,6 +13,7 @@ import DDSImageItem from "@carbon/ibmdotcom-web-components/es/components-react/i
 export default function Image(content) {
   const { alt, defaultSrc, border, heading, copy, lightbox, imageItems } =
     content?.fields || {};
+  const { slot } = content || {};
 
   const { url } = defaultSrc?.fields?.file || {};
   return (
@@ -23,6 +24,7 @@ export default function Image(content) {
       heading={heading}
       copy={copy}
       lightbox={lightbox}
+      slot={slot}
     >
       {!imageItems
         ? undefined

--- a/packages/ibmdotcom-web-components/components/LeavingIBM.js
+++ b/packages/ibmdotcom-web-components/components/LeavingIBM.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSLeavingIBMContainer from "@carbon/ibmdotcom-web-components/es/components-react/leaving-ibm/leaving-ibm-container";
+
+export default function LeavingIBM() {
+
+  return (
+		<DDSLeavingIBMContainer></DDSLeavingIBMContainer>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/LinkWithIcon.js
+++ b/packages/ibmdotcom-web-components/components/LinkWithIcon.js
@@ -37,14 +37,17 @@ const iconMap = {
 };
 
 export default function LinkWithIcon(content) {
-  const { iconPlacement, disabled, href, text, icon, slot } =
+  const { iconPlacement, disabled, href, text, icon, slot, leavingIbm } =
     content?.fields || {};
+
+    const leavingBoolean = !leavingIbm ? undefined : leavingIbm;
   return (
     <DDSLinkWithIcon
       iconPlacement={iconPlacement}
       disabled={disabled}
       href={href}
       slot={slot}
+      data-leaving-ibm={leavingBoolean}
     >
       {text} {iconMap[icon]}
     </DDSLinkWithIcon>

--- a/packages/ibmdotcom-web-components/components/LocaleModal.js
+++ b/packages/ibmdotcom-web-components/components/LocaleModal.js
@@ -1,0 +1,21 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import DDSLocaleModalContainer from "@carbon/ibmdotcom-web-components/es/components-react/locale-modal/locale-modal-container";
+
+export default function LeavingIBM(content) {
+
+	const { openOnLoad, localeList, langDisplay } = content?.fields || {};
+
+	const open = !openOnLoad ? undefined : openOnLoad;
+
+  return (
+		<DDSLocaleModalContainer open={open} localeList={localeList} langDisplay={langDisplay}></DDSLocaleModalContainer>
+  );
+}

--- a/packages/ibmdotcom-web-components/components/UniversalBanner.js
+++ b/packages/ibmdotcom-web-components/components/UniversalBanner.js
@@ -1,0 +1,64 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import dynamic from "next/dynamic";
+import DDSUniversalBanner from "@carbon/ibmdotcom-web-components/es/components-react/universal-banner/universal-banner";
+import DDSUniversalBannerHeading from "@carbon/ibmdotcom-web-components/es/components-react/universal-banner/universal-banner-heading";
+import DDSUniversalBannerCopy from "@carbon/ibmdotcom-web-components/es/components-react/universal-banner/universal-banner-copy";
+import DDSUniversalBannerImage from "@carbon/ibmdotcom-web-components/es/components-react/universal-banner/universal-banner-image";
+import DDSImageItem from "@carbon/ibmdotcom-web-components/es/components-react/image/image-item";
+
+const CTA = dynamic(import("./CTA"), {
+  ssr: false,
+});
+
+export default function UniversalBanner(content) {
+  const {
+    heading,
+    copy,
+		ctaButton,
+    image,
+  } = content?.fields || {};
+
+  const buttonFields = {
+    fields: { ...ctaButton?.fields, slot: "cta" },
+  };
+
+  const { defaultSrc, imageItems } = image.fields;
+  const { url } = defaultSrc?.fields?.file || {};
+
+
+  return (
+		<DDSUniversalBanner>
+			<DDSUniversalBannerHeading slot='heading'>{heading}</DDSUniversalBannerHeading>
+			<DDSUniversalBannerCopy slot='copy'>{copy}</DDSUniversalBannerCopy>
+			{ctaButton && <CTA {...buttonFields }/>}
+			{image &&
+				<DDSUniversalBannerImage
+          slot="image"
+          default-src={"https://" + url}
+        >
+          {imageItems &&
+            imageItems.map((image, index) => {
+              const { minWidth } = image.fields;
+              const { url } = image.fields.image.fields.file;
+
+              return (
+                <DDSImageItem
+                  media={`(min-width: ${minWidth})`}
+                  srcset={"https:" + url}
+                  key={index}
+                ></DDSImageItem>
+              );
+            })}
+				</DDSUniversalBannerImage>
+			}
+		</DDSUniversalBanner>
+  );
+}


### PR DESCRIPTION
### Related Ticket(s)
#69 
#67 
#68 
#70 
#49 
#48

### Description
This PR adds the following components to Contentful and their respective wrappers:
* CTA
* Feature card
* Feature section
* Leaving IBM
* Locale modal
* Universal Banner

### Changelog

**New**

- added feature card, section, leaving IBM, locale modal and universal banner
